### PR TITLE
Unreliable devices on the UVic Network

### DIFF
--- a/allegro.go
+++ b/allegro.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -17,6 +18,18 @@ type Data struct {
 	DeviceData      json.RawMessage `json:"device_data"`
 	DeviceTimestamp int64           `json:"device_timestamp"`
 }
+
+// XXX HACK
+// this is to keep track of the devices ip in case we need to ssh into the
+// device for some reason, this is not for production this is only for us
+// while testing the devices on the unreliable network at school
+type DeviceRegistration struct {
+	DeviceId string `json:"device_id"`
+	DeviceIP string `json:"device_ip"`
+}
+
+var DEVICES []DeviceRegistration
+var mu sync.Mutex
 
 func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	fmt.Fprintf(w, "Choral Device Endpoint\n")
@@ -69,10 +82,6 @@ func VerifyPayloadAndSend(w http.ResponseWriter, r *http.Request, _ httprouter.P
 		panic(err)
 	}
 	send(p)
-	fmt.Println(payload.DeviceId)
-	fmt.Println(payload.UserSecret)
-	fmt.Println(string(payload.DeviceData))
-	fmt.Println(payload.DeviceTimestamp)
 }
 
 func send(payload []byte) {
@@ -95,12 +104,62 @@ func send(payload []byte) {
 	//:2181 for zookeeper
 }
 
+// XXX HACK
+// this is to keep track of the devices ip in case we need to ssh into the
+// device for some reason, this is not for production this is only for us
+// while testing the devices on the unreliable network at school
+func ListDevices(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	for _, device := range DEVICES {
+		fmt.Fprintf(w, "%s\t\t\t%s\n", device.DeviceId, device.DeviceIP)
+	}
+}
+
+// XXX HACK
+// this is to keep track of the devices ip in case we need to ssh into the
+// device for some reason, this is not for production this is only for us
+// while testing the devices on the unreliable network at school
+func UpdateDeviceList(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	log.Printf("Post requests work!")
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
+
+	payload := DeviceRegistration{}
+	json.Unmarshal(body, &payload)
+
+	// if the device is already in there then just update it,
+	// otherwise append it
+	mu.Lock()
+
+	defer mu.Unlock()
+
+	for i, device := range DEVICES {
+		if device.DeviceId == payload.DeviceId {
+			DEVICES[i].DeviceIP = payload.DeviceIP
+			return
+		}
+	}
+
+	DEVICES = append(DEVICES, payload)
+}
+
 // Basic handlers to deal with different routes.
 // All requests should come into the same route as POST requests
 func handleRequests() {
 	router := httprouter.New()
 	router.GET("/", Index)
 	router.POST("/", VerifyPayloadAndSend)
+
+	// XXX HACK
+	// this is to keep track of the devices ip in case we need to ssh into the
+	// device for some reason, this is not for production this is only for us
+	// while testing the devices on the unreliable network at school
+	router.GET("/device", ListDevices)
+	router.POST("/device", UpdateDeviceList)
+
 	log.Fatal(http.ListenAndServe(":3000", router))
 }
 

--- a/allegro.go
+++ b/allegro.go
@@ -1,43 +1,43 @@
 package main
 
 import (
-    "fmt"
-    "time"
-    "log"
-    "io/ioutil"
-    "encoding/json"
-    "net/http"
-    "github.com/julienschmidt/httprouter"
-    "github.com/Shopify/sarama"
+	"encoding/json"
+	"fmt"
+	"github.com/Shopify/sarama"
+	"github.com/julienschmidt/httprouter"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
 )
 
 type Data struct {
-    DeviceId        string              `json:"device_id"`
-    UserSecret      string              `json:"user_secret"`
-    DeviceData      json.RawMessage     `json:"device_data"`
-    DeviceTimestamp int64               `json:"device_timestamp"`
+	DeviceId        string          `json:"device_id"`
+	UserSecret      string          `json:"user_secret"`
+	DeviceData      json.RawMessage `json:"device_data"`
+	DeviceTimestamp int64           `json:"device_timestamp"`
 }
 
 func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-    fmt.Fprintf(w, "Choral Device Endpoint\n")
+	fmt.Fprintf(w, "Choral Device Endpoint\n")
 }
 
 func checkTimestamp(timestamp int64) bool {
-    curTime := time.Now().Unix()
-    diff := curTime - timestamp
-    fmt.Println(diff)
-    if diff < 0 || diff > (60*60) {
-        return false
-    }
-    return true
+	curTime := time.Now().Unix()
+	diff := curTime - timestamp
+	fmt.Println(diff)
+	if diff < 0 || diff > (60*60) {
+		return false
+	}
+	return true
 }
 
 func checkId() bool {
-    return true
+	return true
 }
 
 func checkData() bool {
-    return true
+	return true
 }
 
 // Recieves data, in format of {deviceId, data, timestamp}
@@ -47,63 +47,63 @@ func checkData() bool {
 //   - Is data format?
 // then we need to pass it to kafka, which is in another docker container right now
 func VerifyPayloadAndSend(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-    log.Printf("Post requests work!")
+	log.Printf("Post requests work!")
 
-    body, err := ioutil.ReadAll(r.Body)
-    if err != nil {
-        fmt.Println(err)
-        panic(err)
-    }
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
 
-    payload := Data{}
+	payload := Data{}
 
-    json.Unmarshal(body, &payload)
+	json.Unmarshal(body, &payload)
 
-    // do checks concurrently with go func()?
-    if !checkTimestamp(payload.DeviceTimestamp) || !checkId() || !checkData() {
-        fmt.Fprintf(w, "Data has incorrect format")
-    }
+	// do checks concurrently with go func()?
+	if !checkTimestamp(payload.DeviceTimestamp) || !checkId() || !checkData() {
+		fmt.Fprintf(w, "Data has incorrect format")
+	}
 
-    p, err := json.Marshal(&payload)
-    if err != nil {
-        panic(err)
-    }
-    send(p)
-    fmt.Println(payload.DeviceId)
-    fmt.Println(payload.UserSecret)
-    fmt.Println(string(payload.DeviceData))
-    fmt.Println(payload.DeviceTimestamp)
+	p, err := json.Marshal(&payload)
+	if err != nil {
+		panic(err)
+	}
+	send(p)
+	fmt.Println(payload.DeviceId)
+	fmt.Println(payload.UserSecret)
+	fmt.Println(string(payload.DeviceData))
+	fmt.Println(payload.DeviceTimestamp)
 }
 
 func send(payload []byte) {
-    config := sarama.NewConfig()
-    config.Producer.Return.Successes = true
-    config.Producer.RequiredAcks = sarama.WaitForAll
-    brokers := []string{"localhost:9092"}
-    producer, err := sarama.NewSyncProducer(brokers, config)
-    if err != nil {
-        panic(err)
-    }
-    topic := "choraldatastream"
-    msg := &sarama.ProducerMessage{
-        Topic: topic,
-        Value: sarama.ByteEncoder(payload),
-    }
-    partition, offset, err := producer.SendMessage(msg)
-    fmt.Printf("Message is stored in topic(%s)/partition(%d)/offset(%d)\n", topic, partition, offset)
-    //:9092 for kafka
-    //:2181 for zookeeper
+	config := sarama.NewConfig()
+	config.Producer.Return.Successes = true
+	config.Producer.RequiredAcks = sarama.WaitForAll
+	brokers := []string{"localhost:9092"}
+	producer, err := sarama.NewSyncProducer(brokers, config)
+	if err != nil {
+		panic(err)
+	}
+	topic := "choraldatastream"
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(payload),
+	}
+	partition, offset, err := producer.SendMessage(msg)
+	fmt.Printf("Message is stored in topic(%s)/partition(%d)/offset(%d)\n", topic, partition, offset)
+	//:9092 for kafka
+	//:2181 for zookeeper
 }
 
 // Basic handlers to deal with different routes.
 // All requests should come into the same route as POST requests
 func handleRequests() {
-    router := httprouter.New()
-    router.GET("/", Index)
-    router.POST("/", VerifyPayloadAndSend)
-    log.Fatal(http.ListenAndServe(":3000", router))
+	router := httprouter.New()
+	router.GET("/", Index)
+	router.POST("/", VerifyPayloadAndSend)
+	log.Fatal(http.ListenAndServe(":3000", router))
 }
 
 func main() {
-    handleRequests()
+	handleRequests()
 }

--- a/allegro_test.go
+++ b/allegro_test.go
@@ -1,57 +1,57 @@
 package main
 
 import (
-    "fmt"
-    "time"
-    "math/rand"
-    "encoding/json"
-    "net/http"
-    "bytes"
-    "os/exec"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os/exec"
+	"testing"
+	"time"
 )
 
 var url = "http://localhost:3000/"
 
 type Request struct {
-    DeviceId           string              `json:"device_id"`
-    UserSecret         string              `json:"user_secret"`
-    DeviceData         json.RawMessage     `json:"device_data"`
-    DeviceTimestamp    int64               `json:"device_timestamp"`
+	DeviceId        string          `json:"device_id"`
+	UserSecret      string          `json:"user_secret"`
+	DeviceData      json.RawMessage `json:"device_data"`
+	DeviceTimestamp int64           `json:"device_timestamp"`
 }
 
 // generates a random UUID (this will actually come from the device itself)
 func genRandomId() string {
-    out, err := exec.Command("uuidgen").Output()
-    if err != nil {
-        panic(err)
-    }
-    return string(out)
+	out, err := exec.Command("uuidgen").Output()
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
 }
 
 // generate random string for device id
 // put random data in
 // generate timestamp for time.now()
 func genRandomData() json.RawMessage {
-    rand.Seed(time.Now().UTC().UnixNano())
-    deviceId := genRandomId()
-    userSecret := "some_secret"
-    deviceData := json.RawMessage(`{"data":"some random data"}`)
-    timestamp := time.Now().Unix()
+	rand.Seed(time.Now().UTC().UnixNano())
+	deviceId := genRandomId()
+	userSecret := "some_secret"
+	deviceData := json.RawMessage(`{"data":"some random data"}`)
+	timestamp := time.Now().Unix()
 
-    r := Request{
-        deviceId,
-        userSecret,
-        deviceData,
-        timestamp,
-    }
+	r := Request{
+		deviceId,
+		userSecret,
+		deviceData,
+		timestamp,
+	}
 
-    j, err := json.Marshal(&r)
-    if err != nil {
-        fmt.Println(err)
-        panic(err)
-    }
-    return j
+	j, err := json.Marshal(&r)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
+	return j
 }
 
 // Test sending JSON to running server
@@ -60,17 +60,17 @@ func genRandomData() json.RawMessage {
 // So we could write actual test cases... but we can't do that if we want
 // to use httprouter, which really simplifies the http request handling
 func TestJSONFormat(*testing.T) {
-    fmt.Println("Testing JSON format")
-    JSON := genRandomData()
-    time.Sleep(3000 * time.Millisecond)
+	fmt.Println("Testing JSON format")
+	JSON := genRandomData()
+	time.Sleep(3000 * time.Millisecond)
 
-    req, err := http.NewRequest("POST", url, bytes.NewBuffer(JSON))
-    req.Header.Set("Content-Type", "application/json")
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(JSON))
+	req.Header.Set("Content-Type", "application/json")
 
-    client := &http.Client{}
-    client.Do(req)
-    if err != nil {
-        fmt.Println(err)
-        panic(err)
-    }
+	client := &http.Client{}
+	client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
 }


### PR DESCRIPTION
Golang uses tabs not spaces

As per @james-woo 's request this adds a simple workaround to list all of the devices that we currently have sending data to the Choral Storm cluster. This is not a permanent addition it should be removed when/if we figure out what is causing the network issues.