### PR TITLE
Dockerize Allegro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ChoralAllegro
 node_modules/
+Godeps/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.8
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go-wrapper download   # "go get -d -v ./..."
+RUN go-wrapper install    # "go install -v ./..."
+
+CMD ["go-wrapper", "run"] # ["app"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ We might want to consider using godep for dependency management, especially if w
 
 ## Docker
 
-There is also a docker folder here so you can run this in isolation from ChoralStorm. It takes considerably less memory to do this, and is useful for development purposes. To do this:
+There are two ways to run this project using docker
+
+### With Choral Storm
+
+Run choral storm as described in the readme, then run allegro by running
+
+`docker-compose up`
+
+### Locally
+
+There is also a docker folder so you can run this in isolation from ChoralStorm. It takes considerably less memory to do this, and so it is useful for development purposes. To do this:
 
 1. Ensure you aren't already running the image from ChoralStorm
 2. cd docker

--- a/allegro.go
+++ b/allegro.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 )
@@ -210,7 +211,15 @@ func handleRequests() {
 	config.Producer.Return.Successes = true
 	config.Producer.RequiredAcks = sarama.WaitForAll
 
-	brokers := []string{"localhost:9092"}
+	broker := os.Getenv("KAFKA_URI")
+
+	if broker == "" {
+		broker = "localhost:9092"
+	}
+
+	brokers := []string{broker}
+
+	fmt.Println("Connecting to ", brokers)
 
 	var err error
 	PRODUCER, err = sarama.NewSyncProducer(brokers, config)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.3"
+
+services:
+  choralallegro:
+    build: .
+    command: go run allegro.go
+    ports:
+      - "8081:8081"
+    environment:
+      KAFKA_URI: "kafka:9092"
+    external_links:
+      - kafka
+
+networks:
+  default:
+    external:
+      name: choralstorm
+


### PR DESCRIPTION
We need to have allegro on the choral storm network to make it easy to hit kafka and for the worker from choral web to run. This PR starts the groundwork for that.